### PR TITLE
Goroutine leak async consumer fixes #231

### DIFF
--- a/async/component.go
+++ b/async/component.go
@@ -96,6 +96,7 @@ func (c *Component) processing(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create consumer")
 	}
+	defer cns.Close()
 	c.info["consumer"] = cns.Info()
 
 	chMsg, chErr, err := cns.Consume(ctx)


### PR DESCRIPTION
Signed-off-by: Sotirios Mantziaris <s.mantziaris@thebeat.co>


When retrying the connection the procedure produces a huge amount of goroutins which leak. As a result the system eats up all memory.


defer Closed the consumer