### PR TITLE
Disable jaeger tracing default fixes #236

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The service has some default settings which can be changed via environment varia
 - Service HTTP port, for setting the default HTTP components port to `50000` with `PATRON_HTTP_DEFAULT_PORT`
 - Log level, for setting zerolog with `INFO` log level with `PATRON_LOG_LEVEL`
 - Tracing, for setting up jaeger tracing with
+  - disabled(`true`,`false`) with `PATRON_JAEGER_DISABLED`. Default is disabled.
   - agent address `0.0.0.0:6831` with `PATRON_JAEGER_AGENT`
   - sampler type `probabilistic`with `PATRON_JAEGER_SAMPLER_TYPE`
   - sampler param `0.1` with `PATRON_JAEGER_SAMPLER_PARAM`

--- a/examples/main.go
+++ b/examples/main.go
@@ -43,6 +43,11 @@ func init() {
 		fmt.Printf("failed to set log level env var: %v", err)
 		os.Exit(1)
 	}
+	err = os.Setenv("PATRON_JAEGER_DISABLED", "false")
+	if err != nil {
+		fmt.Printf("failed to set jaeger enabled env vars: %v", err)
+		os.Exit(1)
+	}
 	err = os.Setenv("PATRON_JAEGER_SAMPLER_PARAM", "1.0")
 	if err != nil {
 		fmt.Printf("failed to set sampler env vars: %v", err)

--- a/trace/kafka/kafka_test.go
+++ b/trace/kafka/kafka_test.go
@@ -65,7 +65,7 @@ func TestAsyncProducer_SendMessage_Close(t *testing.T) {
 	ap, err := NewAsyncProducer([]string{seed.Addr()}, Version(sarama.V0_8_2_0.String()))
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
-	err = trace.Setup("test", "1.0.0", "0.0.0.0:6831", jaeger.SamplerTypeProbabilistic, 0.1)
+	err = trace.Setup("test", "1.0.0", "0.0.0.0:6831", jaeger.SamplerTypeProbabilistic, 0.1, true)
 	assert.NoError(t, err)
 	_, ctx := trace.ChildSpan(context.Background(), "123", "cmp")
 	err = ap.Send(ctx, msg)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -37,7 +37,7 @@ var (
 )
 
 // Setup tracing by providing all necessary parameters.
-func Setup(name, ver, agent, typ string, prm float64) error {
+func Setup(name, ver, agent, typ string, prm float64, disabled bool) error {
 	if ver != "" {
 		version = ver
 	}
@@ -52,6 +52,7 @@ func Setup(name, ver, agent, typ string, prm float64) error {
 			BufferFlushInterval: 1 * time.Second,
 			LocalAgentHostPort:  agent,
 		},
+		Disabled: disabled,
 	}
 	time.Sleep(100 * time.Millisecond)
 	metricsFactory := prometheus.New()
@@ -187,7 +188,7 @@ func (r consumerOption) Apply(o *opentracing.StartSpanOptions) {
 	ext.SpanKindConsumer.Apply(o)
 }
 
-// ComponentOpName returns a operation name for a compoent.
+// ComponentOpName returns a operation name for a component.
 func ComponentOpName(cmp, target string) string {
 	return cmp + " " + target
 }

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSetup_Tracer_Close(t *testing.T) {
-	err := Setup("TEST", "1.0.0", "0.0.0.0:6831", "const", 1)
+	err := Setup("TEST", "1.0.0", "0.0.0.0:6831", "const", 1, true)
 	assert.NoError(t, err)
 	err = Close()
 	assert.NoError(t, err)


### PR DESCRIPTION
Disabling jaeger by default


- Added a env var for switching
- set the default to disabled