### PR TITLE
Disabled tracing but keep metrics enabled fixes #236

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ The service has some default settings which can be changed via environment varia
 - Service HTTP port, for setting the default HTTP components port to `50000` with `PATRON_HTTP_DEFAULT_PORT`
 - Log level, for setting zerolog with `INFO` log level with `PATRON_LOG_LEVEL`
 - Tracing, for setting up jaeger tracing with
-  - disabled(`true`,`false`) with `PATRON_JAEGER_DISABLED`. Default is disabled.
   - agent address `0.0.0.0:6831` with `PATRON_JAEGER_AGENT`
   - sampler type `probabilistic`with `PATRON_JAEGER_SAMPLER_TYPE`
   - sampler param `0.1` with `PATRON_JAEGER_SAMPLER_PARAM`

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -59,7 +59,6 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-
   kafka:
     image: confluentinc/cp-kafka:latest
     hostname: "kafka"

--- a/examples/main.go
+++ b/examples/main.go
@@ -43,11 +43,6 @@ func init() {
 		fmt.Printf("failed to set log level env var: %v", err)
 		os.Exit(1)
 	}
-	err = os.Setenv("PATRON_JAEGER_DISABLED", "false")
-	if err != nil {
-		fmt.Printf("failed to set jaeger enabled env vars: %v", err)
-		os.Exit(1)
-	}
 	err = os.Setenv("PATRON_JAEGER_SAMPLER_PARAM", "1.0")
 	if err != nil {
 		fmt.Printf("failed to set sampler env vars: %v", err)

--- a/service.go
+++ b/service.go
@@ -156,16 +156,7 @@ func SetupLogging(name, version string) error {
 }
 
 func (s *Service) setupDefaultTracing(name, version string) error {
-	disabled := true
 	var err error
-
-	disabledEnv, ok := os.LookupEnv("PATRON_JAEGER_DISABLED")
-	if ok {
-		disabled, err = strconv.ParseBool(disabledEnv)
-		if err != nil {
-			return errors.Wrap(err, "env var for jaeger enable is not valid")
-		}
-	}
 
 	agent, ok := os.LookupEnv("PATRON_JAEGER_AGENT")
 	if !ok {
@@ -177,8 +168,8 @@ func (s *Service) setupDefaultTracing(name, version string) error {
 		tp = jaeger.SamplerTypeProbabilistic
 	}
 	info.UpsertConfig("jaeger-agent-sampler-type", tp)
-	var prmVal = 0.1
-	var prm = "0.1"
+	var prmVal = 0.0
+	var prm = "0.0"
 
 	if prm, ok := os.LookupEnv("PATRON_JAEGER_SAMPLER_PARAM"); ok {
 		prmVal, err = strconv.ParseFloat(prm, 64)
@@ -188,8 +179,8 @@ func (s *Service) setupDefaultTracing(name, version string) error {
 	}
 
 	info.UpsertConfig("jaeger-agent-sampler-param", prm)
-	log.Infof("setting up default tracing to disabled: %v %s, %s with param %s", disabled, agent, tp, prm)
-	return trace.Setup(name, version, agent, tp, prmVal, disabled)
+	log.Infof("setting up default tracing %s, %s with param %s", agent, tp, prm)
+	return trace.Setup(name, version, agent, tp, prmVal)
 }
 
 func (s *Service) createHTTPComponent() (Component, error) {

--- a/trace/kafka/kafka_test.go
+++ b/trace/kafka/kafka_test.go
@@ -65,7 +65,7 @@ func TestAsyncProducer_SendMessage_Close(t *testing.T) {
 	ap, err := NewAsyncProducer([]string{seed.Addr()}, Version(sarama.V0_8_2_0.String()))
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
-	err = trace.Setup("test", "1.0.0", "0.0.0.0:6831", jaeger.SamplerTypeProbabilistic, 0.1, true)
+	err = trace.Setup("test", "1.0.0", "0.0.0.0:6831", jaeger.SamplerTypeProbabilistic, 0.1)
 	assert.NoError(t, err)
 	_, ctx := trace.ChildSpan(context.Background(), "123", "cmp")
 	err = ap.Send(ctx, msg)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -37,7 +37,7 @@ var (
 )
 
 // Setup tracing by providing all necessary parameters.
-func Setup(name, ver, agent, typ string, prm float64, disabled bool) error {
+func Setup(name, ver, agent, typ string, prm float64) error {
 	if ver != "" {
 		version = ver
 	}
@@ -52,7 +52,6 @@ func Setup(name, ver, agent, typ string, prm float64, disabled bool) error {
 			BufferFlushInterval: 1 * time.Second,
 			LocalAgentHostPort:  agent,
 		},
-		Disabled: disabled,
 	}
 	time.Sleep(100 * time.Millisecond)
 	metricsFactory := prometheus.New()

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSetup_Tracer_Close(t *testing.T) {
-	err := Setup("TEST", "1.0.0", "0.0.0.0:6831", "const", 1, true)
+	err := Setup("TEST", "1.0.0", "0.0.0.0:6831", "const", 1)
 	assert.NoError(t, err)
 	err = Close()
 	assert.NoError(t, err)


### PR DESCRIPTION
When disabling tracing, metrics are disabled too.


Setting the param value of the sampler to default 0 disables tracing effectively but keeps metrics.