### PR TITLE
Term signal checked on async retry fixes #230

### DIFF
--- a/async/component.go
+++ b/async/component.go
@@ -80,6 +80,9 @@ func (c *Component) Run(ctx context.Context) error {
 		if err == nil {
 			return nil
 		}
+		if ctx.Err() == context.Canceled {
+			break
+		}
 		c.consumerErrorsInc()
 		if c.retries > 0 {
 			log.Errorf("failed run, retry %d/%d with %v wait: %v", i, c.retries, c.retryWait, err)


### PR DESCRIPTION
When the async component tries to reconnect and the SIGTERM is emmited it is ignored.


Check the context for cancellation inside async component retry.