### PR TITLE
HTTP raw route should be traceable (fixes #245)

### DIFF
--- a/sync/http/health.go
+++ b/sync/http/health.go
@@ -33,5 +33,5 @@ func healthCheckRoute(hcf HealthCheckFunc) Route {
 			w.WriteHeader(http.StatusOK)
 		}
 	}
-	return NewRouteRaw("/health", http.MethodGet, f)
+	return NewRouteRaw("/health", http.MethodGet, f, false)
 }

--- a/sync/http/info.go
+++ b/sync/http/info.go
@@ -36,5 +36,5 @@ func infoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func infoRoute() Route {
-	return NewRouteRaw("/info", http.MethodGet, infoHandler)
+	return NewRouteRaw("/info", http.MethodGet, infoHandler, false)
 }

--- a/sync/http/metric.go
+++ b/sync/http/metric.go
@@ -7,5 +7,5 @@ import (
 )
 
 func metricRoute() Route {
-	return NewRouteRaw("/metrics", http.MethodGet, promhttp.Handler().ServeHTTP)
+	return NewRouteRaw("/metrics", http.MethodGet, promhttp.Handler().ServeHTTP, false)
 }

--- a/sync/http/profiling.go
+++ b/sync/http/profiling.go
@@ -7,17 +7,17 @@ import (
 
 func profilingRoutes() []Route {
 	return []Route{
-		NewRouteRaw("/debug/pprof/", http.MethodGet, profIndex),
-		NewRouteRaw("/debug/pprof/allocs/", http.MethodGet, pprofAllocsIndex),
-		NewRouteRaw("/debug/pprof/cmdline/", http.MethodGet, profCmdline),
-		NewRouteRaw("/debug/pprof/profile/", http.MethodGet, profProfile),
-		NewRouteRaw("/debug/pprof/symbol/", http.MethodGet, profSymbol),
-		NewRouteRaw("/debug/pprof/trace/", http.MethodGet, profTrace),
-		NewRouteRaw("/debug/pprof/heap/", http.MethodGet, profHeap),
-		NewRouteRaw("/debug/pprof/goroutine/", http.MethodGet, profGoroutine),
-		NewRouteRaw("/debug/pprof/block/", http.MethodGet, profBlock),
-		NewRouteRaw("/debug/pprof/threadcreate/", http.MethodGet, profThreadcreate),
-		NewRouteRaw("/debug/pprof/mutex/", http.MethodGet, profMutex),
+		NewRouteRaw("/debug/pprof/", http.MethodGet, profIndex, false),
+		NewRouteRaw("/debug/pprof/allocs/", http.MethodGet, pprofAllocsIndex, false),
+		NewRouteRaw("/debug/pprof/cmdline/", http.MethodGet, profCmdline, false),
+		NewRouteRaw("/debug/pprof/profile/", http.MethodGet, profProfile, false),
+		NewRouteRaw("/debug/pprof/symbol/", http.MethodGet, profSymbol, false),
+		NewRouteRaw("/debug/pprof/trace/", http.MethodGet, profTrace, false),
+		NewRouteRaw("/debug/pprof/heap/", http.MethodGet, profHeap, false),
+		NewRouteRaw("/debug/pprof/goroutine/", http.MethodGet, profGoroutine, false),
+		NewRouteRaw("/debug/pprof/block/", http.MethodGet, profBlock, false),
+		NewRouteRaw("/debug/pprof/threadcreate/", http.MethodGet, profThreadcreate, false),
+		NewRouteRaw("/debug/pprof/mutex/", http.MethodGet, profMutex, false),
 	}
 }
 

--- a/sync/http/route.go
+++ b/sync/http/route.go
@@ -40,6 +40,6 @@ func NewRoute(p string, m string, pr sync.ProcessorFunc, trace bool) Route {
 }
 
 // NewRouteRaw creates a new route from a HTTP handler.
-func NewRouteRaw(p string, m string, h http.HandlerFunc) Route {
-	return Route{Pattern: p, Method: m, Handler: h, Trace: false}
+func NewRouteRaw(p string, m string, h http.HandlerFunc, trace bool) Route {
+	return Route{Pattern: p, Method: m, Handler: h, Trace: trace}
 }

--- a/sync/http/route_test.go
+++ b/sync/http/route_test.go
@@ -42,7 +42,7 @@ func TestNewDeleteRoute(t *testing.T) {
 	assert.True(t, r.Trace)
 }
 func TestNewRouteRaw(t *testing.T) {
-	r := NewRouteRaw("/index", http.MethodGet, nil)
+	r := NewRouteRaw("/index", http.MethodGet, nil, false)
 	assert.Equal(t, "/index", r.Pattern)
 	assert.Equal(t, "GET", r.Method)
 	assert.False(t, r.Trace)


### PR DESCRIPTION
## Which problem is this PR solving?

HTTP raw routes could not be traced.

## Short description of the changes

Raw routes allow for tracing via parameter.